### PR TITLE
CLI: Specifying options for help and parsing 

### DIFF
--- a/bin/blobs-put.js
+++ b/bin/blobs-put.js
@@ -6,7 +6,20 @@ var isTTY = tty.isatty(0)
 
 module.exports = blobsPut
 
-blobsPut.usage = 'dat blobs put <row> [file-path-to-read] [--name=blob-name-to-use-as-key] [--version=row-version-to-update]'
+blobsPut.usage = 'dat blobs put <row> [options]'
+
+blobsPut.options = [
+  {
+    name: 'name',
+    abbr: 'n',
+    help: 'blob name to use as key'
+  },
+  {
+    name: 'version',
+    abbr: 'v',
+    help: 'row version to update'
+  }
+]
 
 function blobsPut(dat, opts, cb) {
   var args = opts._.slice(2)

--- a/bin/blobs-put.js
+++ b/bin/blobs-put.js
@@ -18,6 +18,12 @@ blobsPut.options = [
     name: 'version',
     abbr: 'v',
     help: 'row version to update'
+  },
+  {
+    name: 'quiet',
+    abbr: 'q',
+    boolean: true,
+    help: 'less logging'
   }
 ]
 
@@ -28,7 +34,7 @@ function blobsPut(dat, opts, cb) {
   var blob = args[1]
   if (!opts.name && !blob) return cb(new Error('Must either specify a blob name (--name) to use or a filename. '))
   var row = { key: key }
-  var version = opts.version || opts.v
+  var version = opts.version
   
   dat.get(key, { version: version }, function(err, existing) {
     if (existing) {

--- a/bin/blobs.js
+++ b/bin/blobs.js
@@ -1,18 +1,20 @@
-module.exports = rows
+module.exports = blobs
 
 var subModules = {
   'put': './blobs-put',
   'get': './blobs-get',
 }
 
-rows.commands = {
+blobs.commands = {
   'put': require('./blobs-put'),
   'get': require('./blobs-get')
 }
 
-var usage = rows.usage = 'dat blobs <put|get> [options]'
+blobs.noDat = true
+
+var usage = blobs.usage = 'dat blobs <put|get> [options]'
   
-function rows(dat, opts, cb) {
+function blobs(dat, opts, cb) {
   return cb(new Error('Usage: ' + usage))
 }
     

--- a/bin/blobs.js
+++ b/bin/blobs.js
@@ -1,22 +1,19 @@
 module.exports = rows
 
-var usage = 'dat blobs <put|get>'
-
 var subModules = {
   'put': './blobs-put',
   'get': './blobs-get',
 }
 
-rows.usage = function (opts) {
-  var modulePath = subModules[opts._[1]]
-  if(!modulePath) return usage
-    return require(modulePath).usage
+rows.commands = {
+  'put': require('./blobs-put'),
+  'get': require('./blobs-get')
 }
+
+var usage = rows.usage = 'dat blobs <put|get> [options]'
   
 function rows(dat, opts, cb) {
-  var modulePath = subModules[opts._[1]]
-  if(!modulePath) return cb(new Error('Usage: ' + usage))
-    require(modulePath)(dat, opts,cb)
+  return cb(new Error('Usage: ' + usage))
 }
     
     

--- a/bin/cat.js
+++ b/bin/cat.js
@@ -12,6 +12,39 @@ cat.usage = [
  'dat cat',
  'stream the most recent of all rows'
  ].join(EOL)
+ 
+ cat.options = [
+   {
+     name: 'format',
+     abbr: 'f',
+     help: 'specify output format'
+   },
+  {
+    name: 'csv',
+    help: 'output as csv',
+    boolean: true,
+  },
+  {
+    name: 'json',
+    help: 'output as json',
+    boolean: true
+  },
+  {
+    name: 'ndjson',
+    help: 'output as newline delimited json',
+    boolean: true
+  },
+  {
+    name: 'sse',
+    help: 'output as server-sent events',
+    boolean: true
+  },
+  {
+    name: 'live',
+    help: 'stream live changes (does not support json output)',
+    boolean: true
+  }
+ ]
 
 function cat(dat, opts, cb) {
   if (!opts) opts = {}

--- a/bin/clone.js
+++ b/bin/clone.js
@@ -5,6 +5,15 @@ module.exports = clone
 
 clone.usage = ['dat clone <remoteurl>', 'download a dat locally'].join(EOL)
 
+clone.options = [
+  {
+    name: 'quiet',
+    abbr: 'q',
+    boolean: true,
+    help: 'do not log progress'
+  }
+]
+
 function clone(dat, opts, cb) {
   if (dat.storage && dat.storage.change > 0) return cb(new Error('Cannot clone into existing dat repo'))
   var remote = opts._[1]

--- a/bin/clone.js
+++ b/bin/clone.js
@@ -7,12 +7,20 @@ clone.usage = ['dat clone <remoteurl>', 'download a dat locally'].join(EOL)
 
 clone.options = [
   {
+    name: 'skim',
+    abbr: 's',
+    boolean: true,
+    help: ' only tabular data will be cloned locally'
+  },
+  {
     name: 'quiet',
     abbr: 'q',
     boolean: true,
     help: 'do not log progress'
   }
 ]
+
+clone.noDat = true
 
 function clone(dat, opts, cb) {
   if (dat.storage && dat.storage.change > 0) return cb(new Error('Cannot clone into existing dat repo'))

--- a/bin/help.js
+++ b/bin/help.js
@@ -2,7 +2,11 @@ var ansimd = require('ansimd')
 var fs = require('fs')
 var path = require('path')
 
-module.exports = function(dat, opts, cb) {
+module.exports = help
+
+help.noDat = true
+
+function help(dat, opts, cb) {
   var help = fs.readFileSync(path.join(__dirname, '..', 'docs', 'cli-usage.md'))
   console.log(ansimd(help))
   process.nextTick(cb)

--- a/bin/import.js
+++ b/bin/import.js
@@ -16,11 +16,50 @@ importCmd.usage = ['dat import [<file>]',
   'also allows piping, e.g. cat file.json | dat import --json'
 ].join(EOL)
 
+importCmd.options = [
+  {
+    name: 'format',
+    abbr: 'f',
+    help: 'specify format'
+  },
+  {
+    name: 'json',
+    boolean: true,
+    help: 'parse json'
+  },
+  {
+    name: 'csv',
+    boolean: true,
+    help: 'parse character separated values'
+  },
+  {
+    name: 'tsv',
+    boolean: true,
+    help: 'parse tab separated values'
+  },
+  {
+    name: 'separator',
+    default: ',',
+    help: 'character to use as csv delimiter'
+  },
+  {
+    name: 'results',
+    boolean: true,
+    help: 'show results of import'
+  },
+  {
+    name: 'quiet',
+    abbr: 'q',
+    boolean: true,
+    help: 'less logging'
+  }
+]
+
 function importCmd(dat, opts, cb) {
   var filename = opts._[1]
   var input = null
 
-  var quiet = opts.quiet || opts.q
+  var quiet = opts.quiet
   
   if (filename === '-' || (!filename && !inIsTTY) || opts.stdin) {
     if (!quiet) console.error('No import file specified, using STDIN as input')
@@ -42,7 +81,7 @@ function importCmd(dat, opts, cb) {
 
   if (!input) return cb(new Error('You must specify an input file'))
 
-  var format = opts.format || opts.f
+  var format = opts.format
   if (format) opts[format] = true
 
   var writer = dat.createWriteStream(opts)

--- a/bin/import.js
+++ b/bin/import.js
@@ -18,6 +18,10 @@ importCmd.usage = ['dat import [<file>]',
 
 importCmd.options = [
   {
+    name: 'primary',
+    help: 'specify a primary key to use'
+  },
+  {
     name: 'format',
     abbr: 'f',
     help: 'specify format'

--- a/bin/init.js
+++ b/bin/init.js
@@ -9,7 +9,6 @@ init.usage = ['dat init', 'initialize dat store'].join(EOL)
 init.options = [
   {
     name: 'prompt',
-    abbr: 'p',
     default: true,
     boolean: true,
     help: 'show prompt'
@@ -28,6 +27,7 @@ init.options = [
  }
 ]
 
+init.noDat = true
 
 function init(dat, opts, cb) {
   dat.exists(opts, function(exists) {

--- a/bin/init.js
+++ b/bin/init.js
@@ -6,6 +6,28 @@ module.exports = init
 
 init.usage = ['dat init', 'initialize dat store'].join(EOL)
 
+init.options = [
+  {
+    name: 'prompt',
+    abbr: 'p',
+    default: true,
+    boolean: true,
+    help: 'show prompt'
+  },
+  {
+    name: 'name', 
+    help: 'name of the dat'
+  },
+  {
+    name: 'description',
+    help: 'description of the dat'
+  },
+  {
+    name: 'publisher',
+    help: 'publisher of the dat'
+ }
+]
+
 
 function init(dat, opts, cb) {
   dat.exists(opts, function(exists) {

--- a/bin/listen.js
+++ b/bin/listen.js
@@ -2,7 +2,16 @@ var EOL = require('os').EOL
 
 module.exports = listen
 
-listen.usage = ['dat listen [--port=<port>]', 'Start a dat server'].join(EOL)
+listen.usage = ['dat listen', 'Start a dat server'].join(EOL)
+
+listen.options = [
+  {
+    name: 'port',
+    abbr: 'p',
+    default: 6461,
+    help: 'port the dat will listen to'
+  }
+]
 
 function listen(dat, opts, cb) {
   dat.listen(opts.port, opts, function(err, port) {

--- a/bin/listen.js
+++ b/bin/listen.js
@@ -7,7 +7,6 @@ listen.usage = ['dat listen', 'Start a dat server'].join(EOL)
 listen.options = [
   {
     name: 'port',
-    abbr: 'p',
     default: 6461,
     help: 'port the dat will listen to'
   }

--- a/bin/pull.js
+++ b/bin/pull.js
@@ -5,6 +5,15 @@ module.exports = pull
 
 pull.usage = ['dat pull <remoteurl>', 'pull data from another dat'].join(EOL)
 
+pull.options = [
+  {
+    name: 'quiet',
+    abbr: 'q',
+    boolean: true,
+    help: 'less logging'
+  }
+]
+
 function pull(dat, opts, cb) {
   var remote = opts._[1]
   var pull = dat.pull(remote, opts, cb)

--- a/bin/push.js
+++ b/bin/push.js
@@ -6,6 +6,21 @@ module.exports = push
 
 push.usage = ['dat push <remoteurl>', 'push data to another dat'].join(EOL)
 
+push.options = [
+  {
+    name: 'results',
+    abbr: 'r',
+    boolean: true,
+    help: 'log rows that are pushed'
+  },
+  {
+    name: 'quiet',
+    abbr: 'q',
+    boolean: true,
+    help: 'less logging'
+  }
+]
+
 function push(dat, opts, cb) {
   var remote = opts._[1]
   var push = dat.push(remote, opts, cb)

--- a/bin/rows-get.js
+++ b/bin/rows-get.js
@@ -2,6 +2,14 @@ module.exports = rowsGet
 
 rowsGet.usage = 'dat rows get <rowKey> [<version>]'
 
+rowsGet.options = [
+  {
+    name: 'version',
+    abbr: 'v',
+    help: 'version of the key'
+  }
+]
+
 function rowsGet(dat, opts, cb) {
   var args = opts._.slice(2)
   if(args.length === 0) return cb(new Error('Usage: ' + rowsGet.usage))

--- a/bin/rows-put.js
+++ b/bin/rows-put.js
@@ -3,11 +3,25 @@ var concat = require('concat-stream')
 
 module.exports = rowsPut
 
-rowsPut.usage = 'dat rows put <file-path-to-read> [--key=row-key-to-use]'
+rowsPut.usage = 'dat rows put <file-path-to-read>'
+
+rowsPut.options = [
+  {
+    name: 'key',
+    abbr: 'k',
+    help: 'row key to use'
+  },
+  {
+    name: 'quiet',
+    abbr: 'q',
+    boolean: true,
+    help: 'less logging'
+  }
+]
 
 function rowsPut(dat, opts, cb) {
   var args = opts._.slice(2)
-  var key = opts.key || opts.k
+  var key = opts.key
   var file = args[0]
   
   if(file && file !== '-') {

--- a/bin/rows.js
+++ b/bin/rows.js
@@ -1,22 +1,14 @@
 module.exports = rows
 
-var usage = 'dat rows <put|get|delete>'
+var usage = rows.usage  =  'dat rows <put|get|delete>'
 
-var subModules = {
-  'put': './rows-put',
-  'get': './rows-get',
-  'delete': './rows-delete'
-}
-
-rows.usage = function (opts) {
-  var modulePath = subModules[opts._[1]]
-  if(!modulePath) return usage
-  return require(modulePath).usage
+rows.commands = {
+  'put': require('./rows-put'),
+  'get': require('./rows-get'),
+  'delete': require('./rows-delete')
 }
     
 function rows(dat, opts, cb) {
-  var modulePath = subModules[opts._[1]]
-  if(!modulePath) return cb(new Error('Usage: ' + usage))
-  require(modulePath)(dat, opts,cb)
+  return cb(new Error('Usage: ' + usage))
 }
         

--- a/bin/rows.js
+++ b/bin/rows.js
@@ -7,6 +7,8 @@ rows.commands = {
   'get': require('./rows-get'),
   'delete': require('./rows-delete')
 }
+
+rows.noDat = true
     
 function rows(dat, opts, cb) {
   return cb(new Error('Usage: ' + usage))

--- a/bin/version.js
+++ b/bin/version.js
@@ -4,6 +4,8 @@ module.exports = version
 
 version.usage = ['dat version', 'show dat version'].join(EOL)
 
+version.noDat = true
+
 function version(dat, opts, cb) {
   console.log('dat version ' + dat.version)
   process.nextTick(cb)

--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,7 @@ var rimraf = require('rimraf')
 var debug = require('debug')('dat.cli')
 var exit = require('exit')
 var cliclopts = require('cliclopts')
+var leven = require('leven')
 
 var onerror = function(err) {
   console.error('Error: ' + err.message)
@@ -38,9 +39,24 @@ var argv = minimist(process.argv.slice(2))
 var cmd = argv._[0]
 
 if (!bin.hasOwnProperty(cmd)) {
-  if(cmd) console.error('Command not found: ' + cmd + EOL)
-  console.error("Usage: dat <command> [<args>]" + EOL)
-  if(!cmd) {
+  if(cmd) {
+    console.error('Command not found: ' + cmd)
+    var candidates = Object.keys(bin)
+      .filter(function (key) {
+        return leven(key, cmd) < 3
+      })
+      .sort(function (a,b) {
+        return leven(a, cmd) - leven(b, cmd)
+      })
+      .slice(0, 3)
+    if(candidates.length > 0) {
+      console.error(EOL + 'Did you mean:')
+      candidates.forEach(function (candidate) {
+        console.log('  ', candidate)
+      })
+    }
+  } else {
+    console.error("Usage: dat <command> [<args>]" + EOL)
     console.error('where <command> is one of:')
     Object.keys(bin).forEach(function (key) {
       console.error('  ' + key)

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -32,18 +32,6 @@ or
 dat import --csv some_csv.csv
 ```
 
-use a custom newline delimiter:
-
-```
-cat some_csv.csv | dat import --csv --newline $'\r\n'
-```
-
-use a custom value separator:
-
-```
-cat some_tsv.tsv | dat import --csv --separator $'\t'
-```
-
 ## stream NDJSON into dat
 
 You can pipeline Newline Delimited JSON ([NDJSON](http://ndjson.org/)) into dat on stdin and it will be stored

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "basic": "~0.0.1",
     "bops": "~0.1.0",
     "byte-stream": "~2.0.2",
+    "cliclopts": "^1.0.0",
     "concat-stream": "~1.4.3",
     "connections": "~1.0.0",
     "content-addressable-blob-store": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "level-manifest": "~1.2.0",
     "leveldown-prebuilt": "~0.10.2",
     "levelup": "~0.18.2",
+    "leven": "^1.0.1",
     "lexicographic-integer": "~1.1.0",
     "minimist": "~0.2.0",
     "mkdirp": "~0.3.5",


### PR DESCRIPTION
Each command module can now export a `options` array of specified options in the style documented here: https://www.npmjs.com/package/cliclopts

Example for `dat init`:
```js
init.options = [
  {
    name: 'prompt',
    default: true,
    boolean: true,
    help: 'show prompt'
  },
  {
    name: 'name', 
    help: 'name of the dat'
  },
//...
]
```

This data is used to display options on `dat <command> init`, e.g
```
Usage: dat init
initialize dat store

    --prompt              show prompt (default: true)
    --name                name of the dat
    --description         description of the dat
    --publisher           publisher of the dat
```

Also defaults, aliases (specified with 'alias' and 'abbr'  key) and booleans are parsed and passed to the minimist options. This means that also `--path /test/test` usage without `=` is allowed now, since minimist knows when to parse them as boolean flags.

It's still allowed to use undocumented options. I probably also forgot options for the CLI, but I think it's a good start. Let me know if you find some.
