### PR TITLE
ENH: start dat as a daemon background process with listen -d. fixes #206

### DIFF
--- a/bin/listen.js
+++ b/bin/listen.js
@@ -2,9 +2,13 @@ var EOL = require('os').EOL
 
 module.exports = listen
 
-listen.usage = ['dat listen [--port=<port>]', 'Start a dat server'].join(EOL)
+listen.usage = ['dat listen [--port=<port>] [-d]', 'Start a dat server'].join(EOL)
 
 function listen(dat, opts, cb) {
+  if (opts.d) {
+    console.log('Starting dat in the background. \n\nYou can kill it by running \n\n    ps -ef | grep listen \n    kill <pid>\n')
+    require('daemon')()
+  }
   dat.listen(opts.port, opts, function(err, port) {
     if (err) return cb(err)
     console.log('Listening on port ' + port)

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -89,6 +89,12 @@ dat rows get burrito
 dat listen
 ```
 
+## start a dat server to run in the background
+
+```
+dat listen -d
+```
+
 then you can poke around at the REST API:
 
 ```

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "corsify": "~1.0.2",
     "csv-parser": "^1.2.1",
     "cuid": "^1.2.4",
+    "daemon": "^1.1.0",
     "dat-editor-prebuilt": "^1.0.19",
     "dat-remote-blobs": "^2.0.0",
     "dat-replicator": "^3.2.1",


### PR DESCRIPTION
```bash
karissa adsf $ dd listen -d
Starting dat in the background.

You can kill it by running

    ps -ef | grep listen
    kill <pid>
```