### PR TITLE
db option

### DIFF
--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -21,6 +21,7 @@ Returns a new dat instance and either opens the existing underlying database or 
 * `path` (default `process.cwd()`) - if not specified as the first argument to the constructor it will check `options.path` instead
 * `adminUser` and `adminPass` (default `undefined`) - if both are set any write operations will require HTTP basic auth w/ these credentials
 * `leveldown` (default `require('leveldown-prebuilt')`) - pass in a custom leveldown backend
+* `db` - pass in a custom levelup instance. if specified the `leveldown` option will be ignored, and your tabular data will be stored entirely in the `db` instance you pass in
 * `blobs` (default `require('lib/blobs.js')`) - pass in a custom blob store
 * `replicator` (default `require('lib/replicator.js')`) - pass in a custom replicator
 * `remoteAddress` (default `undefined`) - if specified then dat will run in RPC client mode

--- a/index.js
+++ b/index.js
@@ -204,6 +204,7 @@ function readDefaults(paths, opts, cb) {
     data.hooks = opts.hooks || data.hooks || {}
     data.remotes = opts.remotes || data.remotes || {}
 
+    if (opts.db) data.db = opts.db
     if (typeof data.remotes === 'string') data.remotes = {origin:{url:data.remotes}}
     if (typeof opts.remote === 'string') data.remotes.origin = {url:opts.remote}
     if (typeof (opts.remote && opts.remote.origin) === 'string') data.remotes.origin = {url:data.remotes.origin}

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -620,7 +620,15 @@ dat._storage = function(options, cb) {
     this.blobs = this.stats.blobs(backend)
   }
 
-  var leveldb = this._level(options.path, options, function onReady(err) {
+  if (options.db) {
+    var leveldb = options.db
+    if (leveldb.isOpen()) onReady()
+    else leveldb.on('ready', onReady)
+  } else {
+    var leveldb = this._level(options.path, options, onReady)
+  }
+  
+  function onReady(err) {
     if (err) return cb(err)
 
     self.storage = leveldb.rpcServer ? leveldb : ldat(leveldb, {valueEncoding:'binary'})
@@ -650,7 +658,7 @@ dat._storage = function(options, cb) {
     events.EventEmitter.prototype.on.call(self.storage, 'change', function(change) { // .call is need to avoid multilevel warnings
       if (change.subset === 'internal' && change.key === 'schema') self.schema.compile(change.value.toString())
     })
-  })
+  }
 }
 
 dat._ensureExists = function(options, cb) {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "url": "https://github.com/maxogden/dat/issues"
   },
   "devDependencies": {
+    "memdb": "^0.2.0",
     "memdown": "^0.7.1",
     "run-parallel": "^1.0.0",
     "run-series": "^1.0.2",

--- a/test/tests/init.js
+++ b/test/tests/init.js
@@ -161,7 +161,7 @@ module.exports.customDb = function(test, common) {
         var onDiskDat = fs.existsSync(path.join(common.dat1tmp, '.dat', 'store.dat'))
         t.notOk(onDiskDat, 'no dat folder was created')
         memdb.createReadStream().pipe(concat(function(rows) {
-          t.equals(rows.length, 1, 'got 1 row')
+          t.ok(rows.length > 0, 'got rows from memdb')
           dat.destroy(function(err) {
             t.false(err, 'destroy ok')
             t.end()

--- a/test/tests/init.js
+++ b/test/tests/init.js
@@ -152,6 +152,26 @@ module.exports.sameDir = function(test, common) {
   })
 }
 
+module.exports.customDb = function(test, common) {
+  test('instantiate + pass in custom levelup instance', function(t) {
+    var memdb = require('memdb')()
+    var dat = new Dat(common.dat1tmp, { db: memdb }, function ready() {
+      dat.put({'foo': 'bar'}, function(err) {
+        t.notOk(err, 'no put err')
+        var onDiskDat = fs.existsSync(path.join(common.dat1tmp, '.dat', 'store.dat'))
+        t.notOk(onDiskDat, 'no dat folder was created')
+        memdb.createReadStream().pipe(concat(function(rows) {
+          t.equals(rows.length, 1, 'got 1 row')
+          dat.destroy(function(err) {
+            t.false(err, 'destroy ok')
+            t.end()
+          })
+        }))
+      })
+    })
+  })
+}
+
 module.exports.customBackend = function(test, common) {
   test('instantiate + pass in custom leveldown instance', function(t) {
     var memdown = require('memdown')
@@ -196,6 +216,7 @@ module.exports.all = function (test, common) {
   module.exports.existingRepo(test, common)
   module.exports.existingRepoClone(test, common)
   module.exports.autoPort(test, common)
+  module.exports.customDb(test, common)
   module.exports.customBackend(test, common)
   module.exports.customBlobBackend(test, common)
   // module.exports.close(test, common)


### PR DESCRIPTION
this adds a `db` option to the dat constructor so you can pass in a levelup instance for dat to use. previously you could only pass in a leveldown instance and dat would always create a levelup instance internally.

an example of where this is useful is if you wanted to create a subleveldown in a larger app (to 'partition' a larger leveldb) and initialize a dat using that partition only. this way you can have multiple dats using the same physical leveldb