### PR TITLE
Update 'pull' documentation to not talk about 'push'

### DIFF
--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -303,10 +303,12 @@ Synchronizes local dat with a remote dat by pushing all changes to the remote da
 ## pull
 
 ```js
-dat.pull([cb])
+dat.pull([remote], [cb])
 ```
 
-Synchronizes local dat with the remote dat this one was cloned from by pulling all changes from the remote dat over HTTP. Calls `cb` when done.
+Synchronizes local dat with the remote dat by pulling all changes from the remote dat over HTTP. Calls `cb` when done.
+
+`remote` (default: the url this one was cloned from) should be the base HTTP address of the remote dat, e.g. `http://localhost:6461`.
 
 ### Options
 

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -303,12 +303,10 @@ Synchronizes local dat with a remote dat by pushing all changes to the remote da
 ## pull
 
 ```js
-dat.push(remote, [cb])
+dat.pull([cb])
 ```
 
-Synchronizes local dat with a remote dat by pushing all changes to the remote dat over HTTP. Calls `cb` with `(err)` when done.
-
-`remote` should be the base HTTP address of the remote dat, e.g. `http://localhost:6461`
+Synchronizes local dat with the remote dat this one was cloned from by pulling all changes from the remote dat over HTTP. Calls `cb` when done.
 
 ### Options
 


### PR DESCRIPTION
The documentation of 'pull' seems to be a c&p of the 'push' one. This matches what I'm seeing in the code/my tests.