### PR TITLE
add: `dat serve` support

### DIFF
--- a/bin/defaults.js
+++ b/bin/defaults.js
@@ -23,5 +23,11 @@ module.exports = [
     name: 'verbose',
     boolean: true,
     default: false
+  },
+  {
+    name: 'port',
+    boolean: false,
+    default: 8080,
+    abbr: 'p'
   }
 ]

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -1,9 +1,7 @@
 var abort = require('../lib/util/abort.js')
 var openDat = require('../lib/util/open-dat.js')
 var usage = require('../lib/util/usage.js')('serve.txt')
-
 var http = require('http')
-var dat = require('dat-core')
 
 module.exports = {
   name: 'serve',

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -23,9 +23,9 @@ function startDatServer (args) {
 
     db.status(function (err, status) {
       if (err) abort(err, args)
-      var port = parseInt(args.port)
-      if(!port) abort(new Error('Invalid port specified: ' + port), args)
-      console.log("Starting httpd on port: " + port)
+      var port = parseInt(args.port, 10)
+      if (!port) abort(new Error('Invalid port specified: ' + port), args)
+      console.log('Starting httpd on port: ' + port)
       var server = http.createServer(function (req, res) {
         req.pipe(db.replicate()).pipe(res)
       })

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -1,0 +1,37 @@
+var abort = require('../lib/util/abort.js')
+var openDat = require('../lib/util/open-dat.js')
+var usage = require('../lib/util/usage.js')('serve.txt')
+
+var http = require('http')
+var dat = require('dat-core')
+
+module.exports = {
+  name: 'serve',
+  command: startDatServer,
+  options: [
+    {
+      name: 'port',
+      boolean: false,
+      abbr: 'p'
+    }
+  ]
+}
+
+function startDatServer (args) {
+  if (args.help) return usage()
+
+  openDat(args, function (err, db) {
+    if (err) abort(err, args)
+
+    db.status(function (err, status) {
+      if (err) abort(err, args)
+      var port = parseInt(args.port)
+      if(!port) abort(new Error('Invalid port specified: ' + port), args)
+      console.log("Starting httpd on port: " + port)
+      var server = http.createServer(function (req, res) {
+        req.pipe(db.replicate()).pipe(res)
+      })
+      server.listen(port)
+    })
+  })
+}

--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,8 @@ var config = {
     require('./bin/write.js'),
     require('./bin/read.js'),
     require('./bin/forks.js'),
-    require('./bin/merge.js')
+    require('./bin/merge.js'),
+    require('./bin/serve.js')
   ],
   defaults: require('./bin/defaults.js'),
   none: noMatch

--- a/usage/root.txt
+++ b/usage/root.txt
@@ -15,5 +15,6 @@ commands:
   export      export tabular data from a dataset
   read        read a binary file out of a dataset
   write       write a binary file into a dataset
+  serve       start httpd to host store as http remote
 
 type `dat <command> --help` to view specific command help

--- a/usage/serve.txt
+++ b/usage/serve.txt
@@ -1,0 +1,3 @@
+dat serve [--port=8080]
+
+Start a httpd to host a dat remote.


### PR DESCRIPTION
Support for `dat serve` based off an example script from @mafintosh. I think something simple like this might be very helpful for new users to get up and running with basic clone-push-pull stuff.
