### PR TITLE
BUG #348 missing rimraf package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "pump": "^1.0.0",
     "pumpify": "^1.3.3",
     "relative-date": "^1.1.2",
+    "rimraf": "^2.3.2",
     "single-line-log": "^1.0.0",
     "subcommand": "^2.0.1",
     "through2": "^0.6.3",


### PR DESCRIPTION
On a fresh install

    $ npm install dat -g

and 
```
dat

module.js:340
    throw err;
          ^
Error: Cannot find module 'rimraf'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/clemsos/.nvm/v0.10.26/lib/node_modules/dat/bin/destroy.js:4:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```