### PR TITLE
resolve mdns dat names

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -2,6 +2,8 @@ var http = require('http')
 var getport = require('getport')
 var pump = require('pump')
 var route = require('../lib/serve.js')
+var register = require('register-multicast-dns')
+var config = require('../lib/util/config.js')
 var abort = require('../lib/util/abort.js')
 var openDat = require('../lib/util/open-dat.js')
 var usage = require('../lib/util/usage.js')('serve.txt')
@@ -28,12 +30,19 @@ function startDatServer (args) {
   if (args.help) return usage()
   if (args.port) return serve(parseInt(args.port, 10))
 
+  try {
+    var name = config(args).dat.name + '.dat'
+  } catch (err) {
+    // do nothing
+  }
+
   getport(6442, function (err, port) {
     if (err) abort(err, args)
     return serve(port)
   })
 
   function serve (port) {
+    if (name) register(name)
     openDat(args, function (err, db) {
       if (err) abort(err, args)
       if (!port) abort(new Error('Invalid port: ' + port), args)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "pump": "^1.0.0",
     "pumpify": "^1.3.3",
     "read": "^1.0.6",
+    "register-multicast-dns": "^1.0.1",
     "relative-date": "^1.1.2",
     "resolve": "^1.1.6",
     "rimraf": "^2.3.2",

--- a/usage/serve.txt
+++ b/usage/serve.txt
@@ -1,5 +1,9 @@
 dat serve [--port=6442]
 
-Start an http listener for a dat remote. Supports push/pull/clone.
+  Start an http listener for a dat remote. Supports push/pull/clone. This dat will afterwards be clonable by doing `dat clone http://address-to-this-dat.com` or `dat clone http://{name-of-dat}.dat.local` if you are on the same local network.
 
-  --readonly  -  run with read only permission, so e.g. people can only clone/pull but not push
+Options:
+
+  --readonly
+
+    Run with read only permission, so others can only clone/pull but not push.


### PR DESCRIPTION
This allows you to clone from other people on the same network that are serving a dat by just using the dat name name as the hostname.

On one computer

```
dat init # set name to example
dat import some-data.csv -d test
dat serve
```

On another computer you now simply do

```
dat clone example.dat.local # clones the above dataset
```
