### PR TITLE
Add 'dat changes'

### DIFF
--- a/bin/changes.js
+++ b/bin/changes.js
@@ -3,7 +3,6 @@ var pump = require('pump')
 var abort = require('../lib/util/abort.js')
 var openDat = require('../lib/util/open-dat.js')
 var usage = require('../lib/util/usage.js')('changes.txt')
-var debug = require('debug')('dat-changes')
 
 module.exports = {
   name: 'changes',

--- a/bin/changes.js
+++ b/bin/changes.js
@@ -1,0 +1,27 @@
+var ndjson = require('ndjson')
+var pump = require('pump')
+var abort = require('../lib/util/abort.js')
+var openDat = require('../lib/util/open-dat.js')
+var usage = require('../lib/util/usage.js')('changes.txt')
+var debug = require('debug')('dat-changes')
+
+module.exports = {
+  name: 'changes',
+  command: doChanges,
+  options: [
+  ]
+}
+
+function doChanges (args) {
+  if (args.help) return usage()
+
+  openDat(args, function (err, db) {
+    if (err) abort(err, args)
+
+    args.values = true
+
+    pump(db.createChangesStream(args), ndjson.serialize(), process.stdout, function (err) {
+      if (err) abort(err, args)
+    })
+  })
+}

--- a/bin/changes.js
+++ b/bin/changes.js
@@ -8,6 +8,12 @@ module.exports = {
   name: 'changes',
   command: doChanges,
   options: [
+    {
+      name: 'live',
+      boolean: true,
+      abbr: 'l',
+      default: false
+    }
   ]
 }
 

--- a/cli.js
+++ b/cli.js
@@ -23,6 +23,7 @@ var config = {
     require('./bin/push.js'),
     require('./bin/read.js'),
     require('./bin/replicate.js'),
+    require('./bin/changes.js'),
     require('./bin/serve.js'),
     require('./bin/status.js'),
     require('./bin/write.js')

--- a/docs/cli-docs.md
+++ b/docs/cli-docs.md
@@ -19,6 +19,7 @@ This is the `dat` command line API as of the Beta release.
   - [dat files](#dat-files)
   - [dat replicate](#dat-replicate)
   - [dat serve](#dat-serve)
+  - [dat changes](#dat-changes)
   - [dat destroy](#dat-destroy)
 - [dataset commands](#dataset-commands)
   - [dat import](#dat-import)
@@ -144,6 +145,25 @@ $ dat log --limit=1 --json
 
 `Links` is a list of older versions that are referenced from this current version (forms a directed acyclic graph if drawn).
 
+
+### dat changes
+
+Return a stream of the individual changes in a dat, including puts and deletes. A **change** is the bulding block of a **version**, that is, a version consists of 1 or more changes.
+
+Example output:
+
+```
+$ dat changes
+{"content":"file","type":"put","key":"package.json","dataset":"files","value":{"key":"e77584907396f1e8c899788732d54cf3141ddf1d646e1ed50d35e507e42dd2ba","size":34}}
+{"content":"row","type":"put","key":"cid628kzd00006rxmi5q30gok","dataset":"hello","value":{"hello":"world"}}
+{"content":"row","type":"put","key":"cid628qqb00006uxmnneci14r","dataset":"hello","value":{"hello":"mars"}}
+{"content":"row","type":"put","key":"cid628vi800006wxm2xfv86xa","dataset":"hello","value":{"goodbye":"mars"}}
+```
+
+#### Options
+
+- `live` - Keep returning changes until process is killed
+
 ### dat clone
 
 Clone a new repository from a remote dat to create a new dat.
@@ -173,7 +193,6 @@ dat push <remote>
 
 #### Options
 
-- `live` - Keep pushing even after the initial pushing finishes
 - `bin` - specify path to the `dat` executable if `dat` is not in your path
 
 Example output:

--- a/tests/status-log.js
+++ b/tests/status-log.js
@@ -54,6 +54,29 @@ test('status-log: dat1 log', function (t) {
   st.end()
 })
 
+test('status-log: dat1 changes', function (t) {
+  var st = spawn(t, dat + ' changes', {cwd: dat1})
+  var lines = 0
+  st.stdout.match(function (output) {
+    var data = JSON.parse(output)
+    if (lines === 0) {
+      t.same(data.content, 'file')
+      t.same(data.dataset, 'files')
+      t.same(data.type, 'put')
+      t.ok(data.key)
+    } else {
+      t.same(data.content, 'row')
+      t.same(data.dataset, 'status-test')
+      t.same(data.type, 'put')
+      t.ok(data.key)
+    }
+    lines++
+    return true
+  })
+  st.stderr.empty()
+  st.end()
+})
+
 test('status-log: dat1 log json', function (t) {
   var st = spawn(t, dat + ' log --json', {cwd: dat1})
   st.stdout.match(function (output) {

--- a/usage/changes.txt
+++ b/usage/changes.txt
@@ -1,0 +1,3 @@
+dat changes
+
+Return a stream of changes as the are emitted by dat-core's createChangesStream

--- a/usage/changes.txt
+++ b/usage/changes.txt
@@ -1,3 +1,3 @@
-dat changes
+dat changes [--live]
 
 Return a stream of changes as the are emitted by dat-core's createChangesStream


### PR DESCRIPTION
This allows people to get access to the individual operations inside each dat commit, to set up hooks for things like 'streaming database frontends'. part of the solution to address maxogden/dat#361, maxogden/dat#318, and possibly also maxogden/dat#303