### PR TITLE
adhere to padded-blocks

### DIFF
--- a/bin/read.js
+++ b/bin/read.js
@@ -38,5 +38,4 @@ function handleRead (args) {
       db.close()
     })
   })
-
 }


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.