### PR TITLE
getting dat version via ssh/filesystem

### DIFF
--- a/bin/datasets.js
+++ b/bin/datasets.js
@@ -15,7 +15,7 @@ function handleDatasets (args) {
 
     db.listDatasets(function (err, datasets) {
       if (err) abort(err, args)
-      if (args.json) console.log(JSON.stringify({datasets: datasets}))
+      if (args.json) console.log(JSON.stringify({datasets: datasets}, 2))
       else console.log(datasets.join('\n'))
       db.close()
     })

--- a/bin/status.js
+++ b/bin/status.js
@@ -26,6 +26,9 @@ function handleStatus (args) {
       // and there always is a files dataset because of package.json
       if (status.datasets) status.datasets--
       var datasets = status.datasets
+      status.dat = {
+        version: require('../package.json').version
+      }
 
       var rows = status.rows
       if (status.files) rows -= status.files

--- a/bin/status.js
+++ b/bin/status.js
@@ -3,6 +3,7 @@ var relativeDate = require('relative-date')
 var abort = require('../lib/util/abort.js')
 var openDat = require('../lib/util/open-dat.js')
 var usage = require('../lib/util/usage.js')('status.txt')
+var information = require('../lib/information.js')
 
 module.exports = {
   name: 'status',
@@ -15,33 +16,19 @@ function handleStatus (args) {
   openDat(args, function (err, db) {
     if (err) abort(err, args)
 
-    db.status(function (err, status) {
+    information(db, function (err, data) {
       if (err) abort(err, args)
 
-      // dat-core calls it head, we wanna call it version instead
-      status.version = status.head
-      delete status.head
-
-      // we subtract 1 since we don't want to count the 'files' dataset
-      // and there always is a files dataset because of package.json
-      if (status.datasets) status.datasets--
-      var datasets = status.datasets
-      status.dat = {
-        version: require('../package.json').version
-      }
-
-      var rows = status.rows
-      if (status.files) rows -= status.files
-
       if (args.json) {
-        console.log(JSON.stringify(status))
+        console.log(JSON.stringify(data))
       } else {
+        var status = data.status
         var output = ''
         output += 'Current version is ' + status.version
         if (!status.checkout) output += ' (latest)\n'
         else output += ' (checkout)\n'
-        output += datasets + ' ' + pluralize('dataset', datasets) + ', '
-        output += rows + ' ' + pluralize('key', rows) + ', ' + status.files + ' ' + pluralize('file', status.files) + ', '
+        output += status.datasets.length + ' ' + pluralize('dataset', status.datasets.length) + ', '
+        output += status.rows + ' ' + pluralize('key', status.rows) + ', ' + status.files + ' ' + pluralize('file', status.files) + ', '
         output += status.heads + ' ' + pluralize('fork', status.heads) + ', '
         output += status.versions + ' ' + pluralize('version', status.versions) + ', ' + prettyBytes(status.size) + ' total\n'
         output += 'Last updated ' + relativeDate(status.modified) + ' (' + status.modified + ')'

--- a/lib/information.js
+++ b/lib/information.js
@@ -1,0 +1,19 @@
+var version = require('../package.json').version
+
+module.exports = function (db, cb) {
+  db.status(function (err, status) {
+    if (err) return cb(err)
+
+    // dat-core calls it head, we wanna call it version instead
+    status.version = status.head
+    delete status.head
+
+    if (status.files) status.rows -= status.files
+
+    return cb(null, {
+      status: status,
+      dat: true,
+      version: version
+    })
+  })
+}

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,23 +1,13 @@
 var pump = require('pump')
 var debug = require('debug')('dat-serve')
 var debugStream = require('debug-stream')
-
-var version = require('../package.json').version
+var information = require('./information.js')
 
 module.exports = {
   information: function (db, args, cb) {
-    db.status(function (err, status) {
+    information(db, function (err, data) {
       if (err) return cb(err)
-      db.listDatasets(function (err, datasets) {
-        if (err) return cb(err)
-        var result = {
-          dat: true,
-          version: version,
-          status: status,
-          datasets: datasets
-        }
-        cb(null, JSON.stringify(result))
-      })
+      cb(null, JSON.stringify(data))
     })
   },
   replication: function (db, args) {

--- a/tests/diff.js
+++ b/tests/diff.js
@@ -33,7 +33,7 @@ test('diff: dat1 status as json', function (t) {
   var st = spawn(t, dat + ' status --json', {cwd: dat1})
   st.stdout.match(function (output) {
     try {
-      var json = JSON.parse(output)
+      var json = JSON.parse(output).status
       version = json.version
       return json.version.length === 64 // 32bit hash 2 in hex (64)
     } catch (e) {

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -109,7 +109,7 @@ function conflict (dat1, dat2, dataset, cb) {
     stat.stderr.empty()
     stat.stdout.match(function match (output) {
       try {
-        statusJson = JSON.parse(output)
+        statusJson = JSON.parse(output).status
       } catch (e) {
         statusJson = false
       }
@@ -191,7 +191,7 @@ function fileConflict (dat1, dat2, dataset, filename, cb) {
     stat.stderr.empty()
     stat.stdout.match(function match (output) {
       try {
-        statusJson = JSON.parse(output)
+        statusJson = JSON.parse(output).status
       } catch (e) {
         statusJson = false
       }

--- a/tests/json.js
+++ b/tests/json.js
@@ -48,7 +48,7 @@ test('json: dat clone --json', function (t) {
 
 test('json: dat datasets --json', function (t) {
   var st = spawn(t, dat + ' datasets --json --path=' + dat1, {cwd: tmp})
-  st.stdout.match('{"datasets":["files"]}\n')
+  st.stdout.match('{"datasets":[]}\n')
   st.stderr.empty()
   st.end()
 })

--- a/tests/status-log.js
+++ b/tests/status-log.js
@@ -32,8 +32,9 @@ test('status-log: dat1 status as json', function (t) {
   st.stdout.match(function (output) {
     try {
       var json = JSON.parse(output)
-      t.same(json.version.length, 64) // 32bit hash 2 in hex (64)
-      t.same(json.datasets, 1) // files dataset doesn't count!
+      var status = json.status
+      t.same(status.version.length, 64) // 32bit hash 2 in hex (64)
+      t.same(status.datasets.length, 1) // files dataset doesn't count!
       return true
     } catch (e) {
       return false

--- a/tests/write.js
+++ b/tests/write.js
@@ -82,7 +82,7 @@ test('write: dat3 status as json', function (t) {
   var st = spawn(t, dat + ' status --json', {cwd: dat3})
   st.stdout.match(function (output) {
     try {
-      var json = JSON.parse(output)
+      var json = JSON.parse(output).status
       version = json.version
       return json.version.length === 64 // 32bit hash 2 in hex (64)
     } catch (e) {


### PR DESCRIPTION
When the dat is accessible via http, you can get the dat version, but when you're dealing with ssh you have to do something special to get the version. We haven't even thought about how to include things like addons or configurations of different kinds that should be known by the conusming application.. this needs to be future-proof.

The attached change is just a band-aid, but we really need a canoncial way to describe a dat to the outside world that is the same no matter how you're accessing it -- perhaps `dat status` and `http GET /` should return the same thing.

thoughts?