### PR TITLE
dat add / dont merge

### DIFF
--- a/bin/add.js
+++ b/bin/add.js
@@ -39,11 +39,10 @@ function handleAdd (args) {
   debug('handleAdd', args)
   if (args.help || args._.length === 0) return usage()
 
-  var location = args._[0]
+  var location = path.normalize(args._[0])
   var stream = args._[1]
-  var key = args.key || path.normalize(location)
-
-  if (path.isAbsolute(location)) key = path.basename(location)
+  var key = args.key
+  if (!key) key = path.isAbsolute(location) ? path.basename(location) : location
 
   openDat(args, function (err, db) {
     if (err) abort(err, args)

--- a/bin/add.js
+++ b/bin/add.js
@@ -1,0 +1,39 @@
+var debug = require('debug')('bin/import')
+var usage = require('../lib/util/usage.js')('add.txt')
+var datImport = require('../bin/import.js').command
+var datWrite = require('../bin/write.js').command
+
+module.exports = {
+  name: 'add',
+  command: handleAdd,
+  options: [
+    {
+      name: 'dataset',
+      boolean: false,
+      abbr: 'd'
+    },
+    {
+      name: 'format',
+      boolean: false,
+      abbr: 'f'
+    },
+    {
+      name: 'message',
+      boolean: false,
+      abbr: 'm'
+    },
+    {
+      name: 'key',
+      boolean: false,
+      abbr: 'k'
+    }
+  ]
+}
+
+function handleAdd (args) {
+  debug('handleAdd', args)
+  if (args.help || args._.length === 0) return usage()
+  args.flag = true // for importing data with implicit deletes
+  if (args.dataset) datImport(args)
+  else datWrite(args)
+}

--- a/bin/add.js
+++ b/bin/add.js
@@ -1,4 +1,4 @@
-var basename = require('path').basename
+var path = require('path')
 var pump = require('pump')
 var debug = require('debug')('bin/add')
 
@@ -39,15 +39,17 @@ function handleAdd (args) {
   debug('handleAdd', args)
   if (args.help || args._.length === 0) return usage()
 
-  var path = args._[0]
+  var location = args._[0]
   var stream = args._[1]
-  var key = args.key || basename(path)
+  var key = args.key || path.normalize(location)
+
+  if (path.isAbsolute(location)) key = path.basename(location)
 
   openDat(args, function (err, db) {
     if (err) abort(err, args)
     if (stream === '-') doWrite(process.stdin, db)
     else {
-      createFileStream(path, function (err, inputStream) {
+      createFileStream(location, function (err, inputStream) {
         if (err) abort(err, args)
         doWrite(inputStream, db)
       })

--- a/bin/get.js
+++ b/bin/get.js
@@ -1,8 +1,7 @@
 var debug = require('debug')('bin/get')
+var pump = require('pump')
 
-var datRead = require('../bin/read.js').command
-var datExport = require('../bin/export.js').command
-
+var createExportStream = require('../lib/export.js')
 var abort = require('../lib/util/abort.js')
 var openDat = require('../lib/util/open-dat.js')
 var usage = require('../lib/util/usage.js')('get.txt')
@@ -26,25 +25,48 @@ module.exports = {
 
 function handleGet (args) {
   debug('handleGet', args)
-  if (args.help || args._.length === 0) {
-    return usage()
-  }
+  args.key = args.key || args._[0]
 
-  if (!args.dataset) return datRead(args)
-  if (!args.key) return datExport(args)
+  if (args.help) return usage()
+  if (!args.key && !args.dataset) return usage()
 
   openDat(args, function ready (err, db) {
     if (err) abort(err, args)
-    var key = args._[0].toString()
+    if (!args.dataset) return datRead(db)
+    if (!args.key) return datExport(db)
 
-    debug(key, args)
-    db.get(key, args, function (err, value) {
+    db.get(args.key, args, function (err, value) {
       if (err) {
-        var msg = 'Error: Could not find key ' + key + ' in dataset ' + args.dataset + '.'
+        var msg = 'Error: Could not find key ' + args.key + ' in dataset ' + args.dataset + '.'
         abort(err, args, msg)
       }
       process.stdout.write(JSON.stringify(value))
       db.close()
     })
   })
+
+  function datRead (db) {
+    var opts = {
+      dataset: 'files'
+    }
+
+    debug(args.key, opts)
+
+    var stream = db.createFileReadStream(args.key, opts)
+    pump(stream, process.stdout, function done (err) {
+      if (err) abort(err, args, 'Could not find file with key ' + args.key + ' is it in a dataset?')
+    })
+
+    stream.on('end', function () { db.close() })
+  }
+
+  function datExport (db) {
+    var exportStream = createExportStream(db, args)
+
+    pump(exportStream, process.stdout, function done (err) {
+      if (err) abort(err, args)
+    })
+
+    exportStream.on('end', function () { db.close() })
+  }
 }

--- a/bin/get.js
+++ b/bin/get.js
@@ -1,28 +1,37 @@
 var debug = require('debug')('bin/get')
 
+var datRead = require('../bin/read.js').command
+var datExport = require('../bin/export.js').command
+
 var abort = require('../lib/util/abort.js')
 var openDat = require('../lib/util/open-dat.js')
 var usage = require('../lib/util/usage.js')('get.txt')
 
 module.exports = {
   name: 'get',
-  command: handleRows,
+  command: handleGet,
   options: [
     {
       name: 'dataset',
       boolean: false,
       abbr: 'd'
+    },
+    {
+      name: 'key',
+      boolean: false,
+      abbr: 'k'
     }
   ]
 }
 
-function handleRows (args) {
-  debug('handleRows', args)
+function handleGet (args) {
+  debug('handleGet', args)
   if (args.help || args._.length === 0) {
     return usage()
   }
 
-  if (!args.dataset) abort(new Error('Error: Must specify dataset (-d)'))
+  if (!args.dataset) return datRead(args)
+  if (!args.key) return datExport(args)
 
   openDat(args, function ready (err, db) {
     if (err) abort(err, args)

--- a/bin/read.js
+++ b/bin/read.js
@@ -7,13 +7,7 @@ var usage = require('../lib/util/usage.js')('read.txt')
 module.exports = {
   name: 'read',
   command: handleRead,
-  options: [
-    {
-      name: 'dataset',
-      boolean: false,
-      abbr: 'd'
-    }
-  ]
+  options: []
 }
 
 function handleRead (args) {

--- a/bin/write.js
+++ b/bin/write.js
@@ -1,11 +1,6 @@
-var pump = require('pump')
-var basename = require('path').basename
 var debug = require('debug')('bin/write')
-var openDat = require('../lib/util/open-dat.js')
-var createFileStream = require('../lib/util/create-file-stream.js')
-var abort = require('../lib/util/abort.js')
 var usage = require('../lib/util/usage.js')('write.txt')
-var progress = require('../lib/util/progress.js')
+var datAdd = require('../bin/add.js').command
 
 module.exports = {
   name: 'write',
@@ -36,40 +31,5 @@ function handleWrite (args) {
     return usage()
   }
 
-  var path = args._[0]
-  var stream = args._[1]
-  var key = args.key || basename(path)
-
-  openDat(args, function (err, db) {
-    if (err) abort(err, args)
-    if (stream === '-') doWrite(process.stdin, db)
-    else {
-      createFileStream(path, function (err, inputStream) {
-        if (err) abort(err, args)
-        doWrite(inputStream, db)
-      })
-    }
-  })
-
-  function doWrite (inputStream, db) {
-    var opts = {
-      dataset: 'files',
-      message: args.message
-    }
-
-    var writer = db.createFileWriteStream(key, opts)
-    progress(writer, {bytes: true, verb: 'Storing ' + key})
-    pump(inputStream, writer, function done (err) {
-      if (err) abort(err, args, 'Error: Write failed')
-
-      if (args.json) {
-        var output = {
-          version: db.head
-        }
-        console.log(JSON.stringify(output))
-      } else console.error('Stored ' + key + ' successfully. \nCurrent version is now: ' + db.head)
-
-      db.close()
-    })
-  }
+  return datAdd(args)
 }

--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,7 @@ var config = {
   commands: [
     require('./bin/checkout.js'),
     require('./bin/clone.js'),
+    require('./bin/add.js'),
     require('./bin/datasets.js'),
     require('./bin/delete.js'),
     require('./bin/destroy.js'),

--- a/tests/add.js
+++ b/tests/add.js
@@ -7,57 +7,19 @@ var helpers = require('./helpers')
 var tmp = os.tmpdir()
 var dat = path.resolve(__dirname + '/../cli.js')
 var dat1 = path.join(tmp, 'dat-add-1')
-var dat2 = path.join(tmp, 'dat-add-2')
 
 helpers.onedat(dat1)
 
-test('add: dat add csv', function (t) {
-  var csv = path.resolve(__dirname + '/fixtures/all_hour.csv')
-  var st = spawn(t, dat + ' add ' + csv + ' --key=id --dataset=add-test1', {cwd: dat1})
-  st.stdout.empty()
-  st.stderr.match(/Done importing data/)
-  st.end()
-})
-
-verify('add-test1', dat1)
-
-helpers.onedat(dat2)
-
-test('add: dat add json', function (t) {
-  var json = path.resolve(__dirname + '/fixtures/all_hour.json')
-  var st = spawn(t, dat + ' add ' + json + ' --key=id --dataset=add-test2', {cwd: dat2})
-  st.stdout.empty()
-  st.stderr.match(/Done importing data/)
-  st.end()
-})
-
-test('add: dat add to dataset', function (t) {
+test('add: dat add to file', function (t) {
   var st = spawn(t, "echo 'hello world' | " + dat + ' add test-file.txt -', {cwd: dat1})
   st.stdout.empty()
   st.stderr.match(/Stored test-file\.txt successfully/)
   st.end()
 })
 
-test('add: dat read after write to dataset', function (t) {
-  var st = spawn(t, dat + ' read test-file.txt', {cwd: dat1})
+test('add: dat get after write to dataset', function (t) {
+  var st = spawn(t, dat + ' get test-file.txt', {cwd: dat1})
   st.stderr.empty()
   st.stdout.match('hello world\n')
   st.end()
 })
-
-// helper
-
-function verify (dataset, dir) {
-  test('import: dat export ' + dataset, function (t) {
-    var st = spawn(t, dat + ' export --dataset=' + dataset, {cwd: dir})
-    st.stderr.empty()
-    st.stdout.match(function (output) {
-      var lines = output.split('\n')
-      if (lines.length === 10) {
-        if (JSON.parse(lines[0]).id === 'ak11246285') return true
-        return false
-      }
-    })
-    st.end()
-  })
-}

--- a/tests/add.js
+++ b/tests/add.js
@@ -1,0 +1,63 @@
+var os = require('os')
+var path = require('path')
+var test = require('tape')
+var spawn = require('tape-spawn')
+var helpers = require('./helpers')
+
+var tmp = os.tmpdir()
+var dat = path.resolve(__dirname + '/../cli.js')
+var dat1 = path.join(tmp, 'dat-add-1')
+var dat2 = path.join(tmp, 'dat-add-2')
+
+helpers.onedat(dat1)
+
+test('add: dat add csv', function (t) {
+  var csv = path.resolve(__dirname + '/fixtures/all_hour.csv')
+  var st = spawn(t, dat + ' add ' + csv + ' --key=id --dataset=add-test1', {cwd: dat1})
+  st.stdout.empty()
+  st.stderr.match(/Done importing data/)
+  st.end()
+})
+
+verify('add-test1', dat1)
+
+helpers.onedat(dat2)
+
+test('add: dat add json', function (t) {
+  var json = path.resolve(__dirname + '/fixtures/all_hour.json')
+  var st = spawn(t, dat + ' add ' + json + ' --key=id --dataset=add-test2', {cwd: dat2})
+  st.stdout.empty()
+  st.stderr.match(/Done importing data/)
+  st.end()
+})
+
+test('add: dat add to dataset', function (t) {
+  var st = spawn(t, "echo 'hello world' | " + dat + ' add test-file.txt -', {cwd: dat1})
+  st.stdout.empty()
+  st.stderr.match(/Stored test-file\.txt successfully/)
+  st.end()
+})
+
+test('add: dat read after write to dataset', function (t) {
+  var st = spawn(t, dat + ' read test-file.txt', {cwd: dat1})
+  st.stderr.empty()
+  st.stdout.match('hello world\n')
+  st.end()
+})
+
+// helper
+
+function verify (dataset, dir) {
+  test('import: dat export ' + dataset, function (t) {
+    var st = spawn(t, dat + ' export --dataset=' + dataset, {cwd: dir})
+    st.stderr.empty()
+    st.stdout.match(function (output) {
+      var lines = output.split('\n')
+      if (lines.length === 10) {
+        if (JSON.parse(lines[0]).id === 'ak11246285') return true
+        return false
+      }
+    })
+    st.end()
+  })
+}

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -79,7 +79,7 @@ test('cli: dat get nonexistent key', function (t) {
 
 test('cli: dat get without dataset', function (t) {
   var st = spawn(t, dat + ' get bar --path=' + dat1)
-  st.stderr.match(/Must specify dataset/)
+  st.stderr.match(/Could not find file with key bar/)
   st.stdout.empty()
   st.end()
 })

--- a/tests/get.js
+++ b/tests/get.js
@@ -20,7 +20,7 @@ test('get: dat import dataset', function (t) {
 })
 
 test('get: dat get a key from dataset', function (t) {
-  var st = spawn(t, dat + ' get ak11246293 --dataset=get-test', {cwd: dat1})
+  var st = spawn(t, dat + ' get --key=ak11246293 --dataset=get-test', {cwd: dat1})
   st.stderr.empty()
   st.stdout.match(function (output) {
     try {
@@ -35,21 +35,14 @@ test('get: dat get a key from dataset', function (t) {
   st.end()
 })
 
-test('get: dat get without key errors', function (t) {
-  var st = spawn(t, dat + ' get --dataset=get-test', {cwd: dat1})
+test('get: dat get file with row key', function (t) {
+  var st = spawn(t, dat + ' get --key=ak11246293', {cwd: dat1})
   st.stdout.empty()
-  st.stderr.match(fs.readFileSync(path.join('usage', 'get.txt')).toString() + '\n', 'usage matched')
+  st.stderr.match(/Could not find file with key ak11246293/)
   st.end()
 })
 
-test('get: dat get without dataset errors', function (t) {
-  var st = spawn(t, dat + ' get ak11246293', {cwd: dat1})
-  st.stdout.empty()
-  st.stderr.match(/Must specify dataset/)
-  st.end()
-})
-
-test('get: dat get without key and dataset errors', function (t) {
+test('get: dat get without key and dataset returns usage', function (t) {
   var st = spawn(t, dat + ' get', {cwd: dat1})
   st.stdout.empty()
   st.stderr.match(fs.readFileSync(path.join('usage', 'get.txt')).toString() + '\n', 'usage matched')

--- a/tests/write.js
+++ b/tests/write.js
@@ -134,12 +134,12 @@ test('write: dat read after write from file with new key', function (t) {
 })
 
 test('write: dat write from file with new key with abbr', function (t) {
-  datWrite(t, blobPath, '-d write-test-2 -k new-name-abbr.txt')
+  datWrite(t, blobPath, '-k new-name-abbr.txt')
 })
 
 test('write: dat read after write from file with new key with abbr', function (t) {
   var contents = fs.readFileSync(blobPath).toString()
-  datReadEquals(t, 'new-name-abbr.txt', contents, '-d write-test-2')
+  datReadEquals(t, 'new-name-abbr.txt', contents)
 })
 
 helpers.onedat(dat2)

--- a/usage/add.txt
+++ b/usage/add.txt
@@ -1,0 +1,25 @@
+dat add <filename or - for stdin>
+
+  Write data to dat. Will version data by each row's primary key if imported into a dataset. Otherwise, `dat add` will add the data as a blob (binary object).
+
+Parameters:
+
+  <filename> (required)
+
+    Parse the given file into rows and store at the given dataset. Supply - to accept input on standard in.
+
+Options:
+
+  --dataset=<name> (-d)
+
+    If supplied, will parse the rows into a Dat Dataset with the specified name. A dataset is analogous to a SQL Table or Mongo/CouchDB Collection.
+
+  --format=[ndjson, csv, json] (-f)
+
+    Format for parsing the file, if dataset supplied.
+
+  --key=<column> (-k) (recommended)
+
+    The primary key(s) to use, if dataset supplied. Defaults to auto-generating keys for each row. You can create a compound key by supplying multiple values, for example:
+
+      dat import ... -k <column1> -k <column2> ...

--- a/usage/get.txt
+++ b/usage/get.txt
@@ -1,4 +1,4 @@
-dat get --key=<key> --dataset=<name>
+dat get <filename or key>
 
   Streams data from dat to stdout. If a dataset is supplied, will stream out rows. Otherwise, will stream raw binary data from the blob store. You can supply a combination of key and dataset to get a particular
 
@@ -6,8 +6,4 @@ Options:
 
   --dataset=<name> (-d)
 
-    The dataset to stream out rows.
-
-  --key=<key> (-k)
-
-    The key to lookup inside of a dataset (requires dataset param).
+    The dataset name if data is parsed.

--- a/usage/get.txt
+++ b/usage/get.txt
@@ -1,13 +1,13 @@
-dat get <key>
+dat get --key=<key> --dataset=<name>
 
-  Returns the row with the given primary key.
+  Streams data from dat to stdout. If a dataset is supplied, will stream out rows. Otherwise, will stream raw binary data from the blob store. You can supply a combination of key and dataset to get a particular
 
-Parameters
+Options:
 
-  <key>: required
+  --dataset=<name> (-d)
 
-    The key to lookup.
+    The dataset to stream out rows.
 
-  --dataset (-d): required
+  --key=<key> (-k)
 
-    The dataset associated with that key.
+    The key to lookup inside of a dataset (requires dataset param).

--- a/usage/root.txt
+++ b/usage/root.txt
@@ -18,8 +18,10 @@ descriptive commands:
   keys        List existing keys in a dataset.
 
 data commands:
-  import      Add tabular data to a dataset.
-  export      View tabular data from a dataset.
+  add         Add data to a dat. Uses import or write underneath.
+  get         Get data from a dat. Uses export or read underneath.
+  import      Put new rows into a dataset.
+  export      Get rows from a dataset.
   read        Read a binary file.
   write       Write a binary file.
   delete      Delete a key in a dataset.

--- a/usage/root.txt
+++ b/usage/root.txt
@@ -8,23 +8,15 @@ repository commands:
   checkout    Change view to a given version.
   serve       Start an http server.
 
-descriptive commands:
-  status      Show current status.
-  log         List of changes.
-  files       List all files.
-  datasets    List all datasets.
-  forks       List current forks.
-  diff        See differences between the data in two forks.
-  keys        List existing keys in a dataset.
-
 data commands:
-  add         Add data to a dat. Uses import or write underneath.
-  get         Get data from a dat. Uses export or read underneath.
-  import      Put new rows into a dataset.
-  export      Get rows from a dataset.
-  read        Read a binary file.
-  write       Write a binary file.
-  delete      Delete a key in a dataset.
+  add         Add data to a dat.
+  get         Get data from a dat.
+  delete      Delete a key from a dat.
+  log         List of changes.
+  status      Show current status.
+  ls          List all files and datasets.
+  diff        See differences between the data in two forks.
+  forks       List current forks.
   merge       Merge two forks into one.
 
 type `dat <command> --help` to view specific command help

--- a/usage/write.txt
+++ b/usage/write.txt
@@ -1,5 +1,8 @@
 dat write <location>
 
+  DEPRECATED. Use `dat add` instead
+
+Usage:
   Write binary data into dat. This differs from `import` in that it doesn't parse the file, it just stores it as a binary attachment. `import` is designed for tabular data or key/value data. `write` is meant for large files, blobs, or attachments that you can't parse into rows. Files will appear as links in the same directory as `data.dat`.
 
 Paramters:


### PR DESCRIPTION
Proposal:

* `dat write` becomes `dat add`. `dat write` will alias to `dat add` for backwards compatibility. `dat add --dataset=<>` will perform an import into the dataset with a 'delete' node.
* `dat get` becomes more robust. See the proposed api in usage/get.txt. This deprecates `read`, but it will still exist for backwards compat
* `dat export` and `dat import` stay the same, but are reserved for 'advanced' usage in the docs for custom datatype formats that need to be parsed, like tables.
