### PR TITLE
include readme in status output

### DIFF
--- a/lib/information.js
+++ b/lib/information.js
@@ -1,3 +1,4 @@
+var readme = require('./util/readme.js')
 var getConfig = require('./util/config.js')
 var version = require('../package.json').version
 
@@ -12,15 +13,29 @@ module.exports = function (db, args, cb) {
 
     if (status.files) status.rows -= status.files
 
-    var config = getConfig(args)
+    readme.get(db, function (err, readme) {
+      if (err) onerror(err)
+      else done(null, readme)
+    })
 
-    status.dat = {
-      version: version,
-      name: config.name,
-      description: config.description,
-      publisher: config.publisher
+    function onerror (err) {
+      if (err.message.match(/Key not found/)) return done(null, '')
+      else return cb(err)
     }
 
-    return cb(null, status)
+    function done (err, data) {
+      if (err) return onerror(err)
+      var config = getConfig(args)
+
+      status.dat = {
+        version: version,
+        name: config.name,
+        description: config.description,
+        publisher: config.publisher,
+        readme: data
+      }
+
+      return cb(null, status)
+    }
   })
 }

--- a/lib/util/init-dat.js
+++ b/lib/util/init-dat.js
@@ -81,8 +81,8 @@ module.exports = function (args, cb) {
 
         ask([
           {name: 'name', default: pkg.name || args.name || path.basename(process.cwd())},
-          {name: 'description', default: pkg.description || args.description || pkg['name']},
-          {name: 'publisher', default: pkg.publisher || args.publisher || 'Unknown'}
+          {name: 'description', default: pkg.description || args.description || 'N/A'},
+          {name: 'publisher', default: pkg.publisher || args.publisher || 'N/A'}
         ], cb)
       }
 

--- a/lib/util/readme.js
+++ b/lib/util/readme.js
@@ -1,0 +1,25 @@
+var concat = require('concat-stream')
+var pump = require('pump')
+var str = require('string-to-stream')
+
+module.exports = {}
+
+module.exports.init = function (db, cb) {
+  var opts = {
+    dataset: 'files',
+    message: 'Add Readme',
+    content: 'file'
+  }
+  var readme = '# Readme\n\nThis readme is empty.'
+  pump(str(readme), db.createFileWriteStream('readme.md', opts), function (err) {
+    return cb(err, readme)
+  })
+}
+
+module.exports.get = function (db, cb) {
+  var readStream = db.createFileReadStream('readme.md', {dataset: 'files'})
+  var getReadme = concat(function (data) { cb(null, data.toString()) })
+  pump(readStream, getReadme, function (err) {
+    if (err) cb(err)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "resolve": "^1.1.6",
     "rimraf": "^2.3.2",
     "single-line-log": "^1.0.0",
+    "string-to-stream": "^1.0.1",
     "subcommand": "^2.0.1",
     "through2": "^0.6.3",
     "transport-stream": "^1.4.2"

--- a/tests/status-log.js
+++ b/tests/status-log.js
@@ -34,6 +34,7 @@ test('status-log: dat1 status as json', function (t) {
       var status = JSON.parse(output)
       t.same(status.version.length, 64) // 32bit hash 2 in hex (64)
       t.same(status.datasets.length, 1) // files dataset doesn't count!
+      t.same(status.dat.readme, '', 'has empty readme')
       return true
     } catch (e) {
       return false


### PR DESCRIPTION
This won't create a readme. If one doesn't exist (at `readme.md`), it will return the empty string in `dat status --json`. I thought it better not to generate a readme.md automatically, because the user could have one already they they want to use.

closes #244 