### PR TITLE
reverse entries in log

### DIFF
--- a/bin/log.js
+++ b/bin/log.js
@@ -23,7 +23,7 @@ function handleLog (args) {
 
     var formatter
     if (args.json) formatter = ndjson.serialize()
-    else formatter = through.obj(format)
+    else formatter = through.obj(format), args.reverse = true
     pump(db.createChangesStream(args), formatter, process.stdout, function done (err) {
       if (err) abort(err, args, 'dat: err in versions')
       db.close()

--- a/bin/log.js
+++ b/bin/log.js
@@ -22,8 +22,12 @@ function handleLog (args) {
     if (err) abort(err, args)
 
     var formatter
-    if (args.json) formatter = ndjson.serialize()
-    else formatter = through.obj(format), args.reverse = true
+    if (args.json) {
+      formatter = ndjson.serialize()
+    } else {
+      formatter = through.obj(format)
+      args.reverse = true
+    }
     pump(db.createChangesStream(args), formatter, process.stdout, function done (err) {
       if (err) abort(err, args, 'dat: err in versions')
       db.close()


### PR DESCRIPTION
as requested in #414, all entries in the log are now shown in reverse order (latest first), unless the desired log format is json