### PR TITLE
do not add files in parallel

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,7 @@ Dat.prototype.share = function (cb) {
     }
     console.log('reading', data.filepath)
     var entry = pack.entry({name: data.relname, mode: data.stat.mode})
-    fs.createReadStream(data.filepath).pipe(entry)
-    next()
+    fs.createReadStream(data.filepath).pipe(entry).on('finish', next)
   })
   pump(stream, adder, function (err) {
     if (err) throw err


### PR DESCRIPTION
adding files in parallel might produce inconsistent hashes for the same folder. we'll also run out of file descriptors pretty fast.

off topic, similar to a tarball, you can actually add non-files to a hyperdrive archive. this is needed for things like a container but we can add that later here.