### PR TITLE
Keep track of port between tries

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,14 +154,12 @@ Dat.prototype.joinTcpSwarm = function (opts, cb) {
     else throw err
   })
 
+  if (opts.port) return swarmListen()
   metaLevel.get(link + '-port', function (err, value) {
-    if (err) {
-      if (err.notFound) swarmListen() // no old ports
-      else return cb(err)
-    } else {
-      if (!opts.port) opts.port = Number(value)
-      swarmListen()
-    }
+    if (err && err.notFound) return swarmListen() // no old port
+    if (err) return cb(err)
+    opts.port = Number(value)
+    swarmListen()
   })
 
   function swarmListen () {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "single-line-log": "^1.0.1",
     "speedometer": "^1.0.0",
     "stream-each": "^1.1.0",
+    "subleveldown": "^2.1.0",
     "through2": "^2.0.0",
     "webrtc-swarm": "^2.3.0",
     "xtend": "^4.0.1"


### PR DESCRIPTION
- Use sublevel to track port of specific hashes between tries.
-  Keeps track of port for both download and link. 
- Will use user option if specified regardless of value in db.