### PR TITLE
Add pretty download progress, Update All Progress Outputs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -145,7 +145,7 @@ function printScanProgress (stats, last) {
   var dirCount = stats.directories + 1 // parent folder
   var msg = chalk.bold.blue('Calculating Size: ')
   if (last) msg = chalk.bold.green('Creating Dat Link ')
-  msg += chalk.black(
+  msg += chalk.bold(
     '(' + stats.files + ' files, ' + dirCount + ' folders, ' +
     (stats.size ? prettyBytes(stats.size) + ' total' : '') + ')'
   )

--- a/cli.js
+++ b/cli.js
@@ -156,9 +156,9 @@ function printAddProgress (statsAdd, statsScan) {
   var msg = ''
   var stats = statsAdd
   // make stats API consistent w/ download stats
-  stats.totalStats =  {
+  stats.totalStats = {
     bytesTotal: statsScan.size,
-    filesTotal: statsScan.files,
+    filesTotal: statsScan.files
   }
 
   while (true) {
@@ -210,7 +210,6 @@ function getFileProgressMsg (file, msg) {
     logger.stdout(chalk.green.dim(indent + '[Done] ') + chalk.dim(file.name))
     logger.log('')
   }
-  logger.log(file.stats)
 
   var filePercent = 0
   if (file.stats.bytesTotal > 0) {
@@ -228,17 +227,17 @@ function getFileProgressMsg (file, msg) {
   return msg
 }
 
-function getTotalProgressMsg(stats, statusText, msg) {
+function getTotalProgressMsg (stats, statusText, msg) {
   if (!stats) return ''
   if (!msg) msg = ''
   msg += '\n'
 
+  var bytesProgress = stats.progressStats.bytesDownloaded
+  var fileProgress = stats.progressStats.filesDownloaded
+
   if (stats.progressStats.bytesRead > 0) {
-    var bytesProgress = stats.progressStats.bytesRead
-    var fileProgress = stats.progressStats.filesRead
-  } else {
-    var bytesProgress = stats.progressStats.bytesDownloaded
-    var fileProgress = stats.progressStats.filesDownloaded
+    bytesProgress = stats.progressStats.bytesRead
+    fileProgress = stats.progressStats.filesRead
   }
 
   var totalPer = Math.floor(100 * (bytesProgress / stats.totalStats.bytesTotal))

--- a/fs.js
+++ b/fs.js
@@ -50,11 +50,8 @@ module.exports.createDownloadStream = function (archive, stats) {
         name: item.name,
         stats: downloadStats
       })
-      downloadStats.on('ready', function() {
+      downloadStats.on('ready', function () {
         stats.progress.bytesRead += downloadStats.bytesInitial
-      })
-      downloadStats.on('end', function() {
-
       })
     }
   })

--- a/fs.js
+++ b/fs.js
@@ -36,19 +36,25 @@ module.exports.listEach = function (opts, onEach, cb) {
 
 // `stats` is for rendering progress bars
 module.exports.createDownloadStream = function (archive, stats) {
-  if (!stats) stats = {progressStats: {}, files: []}
-  stats.progressStats.directories = 0
+  if (!stats) stats = {progress: {}, fileQueue: []}
 
   var downloader = through.obj(function (item, enc, next) {
     var downloadStats = archive.download(item, function (err) {
       if (err) return next(err)
-      if (item.type === 'directory') stats.progressStats.directories++
+      if (item.type === 'directory') stats.progress.directories++
+      else stats.progress.filesRead++
       next()
     })
     if (item.type === 'file') {
-      stats.files.push({
+      stats.fileQueue.push({
         name: item.name,
         stats: downloadStats
+      })
+      downloadStats.on('ready', function() {
+        stats.progress.bytesRead += downloadStats.bytesInitial
+      })
+      downloadStats.on('end', function() {
+
       })
     }
   })

--- a/fs.js
+++ b/fs.js
@@ -36,17 +36,23 @@ module.exports.listEach = function (opts, onEach, cb) {
 
 // `stats` is for rendering progress bars
 module.exports.createDownloadStream = function (archive, stats) {
-  if (!stats) stats = {}
-  stats.files = 0
-  stats.directories = 0
+  if (!stats) stats = {progressStats:{}, files:[]}
+  //stats.files = 0
+  stats.progressStats.directories = 0
 
-  var downloader = through.obj(function (entry, enc, next) {
-    archive.download(entry, function (err) {
+  var downloader = through.obj(function (item, enc, next) {
+    var downloadStats = archive.download(item, function (err) {
       if (err) return next(err)
-      if (entry.type === 'directory') stats.directories++
-      else stats.files++
+      if (item.type === 'directory') stats.progressStats.directories++
+      //else stats.files++
       next()
     })
+    if (item.type === 'file') {
+      stats.files.push({
+        name: item.name,
+        stats: downloadStats
+      })
+    }
   })
   downloader.stats = stats
   return downloader

--- a/fs.js
+++ b/fs.js
@@ -36,15 +36,13 @@ module.exports.listEach = function (opts, onEach, cb) {
 
 // `stats` is for rendering progress bars
 module.exports.createDownloadStream = function (archive, stats) {
-  if (!stats) stats = {progressStats:{}, files:[]}
-  //stats.files = 0
+  if (!stats) stats = {progressStats: {}, files: []}
   stats.progressStats.directories = 0
 
   var downloader = through.obj(function (item, enc, next) {
     var downloadStats = archive.download(item, function (err) {
       if (err) return next(err)
       if (item.type === 'directory') stats.progressStats.directories++
-      //else stats.files++
       next()
     })
     if (item.type === 'file') {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ Dat.prototype.addFiles = function (dirs, cb) {
   this.scan(dirs, eachItem, done)
 
   var stats = {
-    totalStats: pack.stats,
+    progressStats: pack.stats,
     files: []
   }
 
@@ -170,7 +170,11 @@ Dat.prototype.download = function (link, dir, cb) {
   var self = this
   if (!cb) cb = function noop () {}
 
-  var stats = {}
+  var stats = {
+    progressStats: {},
+    totalStats: {},
+    files: []
+  }
 
   self.joinTcpSwarm(link, function (err, swarm) {
     if (err) return cb(err)
@@ -182,7 +186,8 @@ Dat.prototype.download = function (link, dir, cb) {
 
     archive.ready(function (err) {
       if (err) return cb(err)
-      swarm.blocks = archive.entries
+      stats.progressStats = archive.stats
+      stats.totalStats.filesTotal = archive.entries
       var download = self.fs.createDownloadStream(archive, stats)
       pump(archive.createEntryStream(), download, function (err) {
         cb(err, swarm)
@@ -190,7 +195,6 @@ Dat.prototype.download = function (link, dir, cb) {
     })
 
     archive.on('file-download', function (entry, data, block) {
-      stats.downloaded += data.length
       stats.downloadRate(data.length)
     })
   })

--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ Dat.prototype.download = function (link, dir, cb) {
         stats.totalStats.bytesTotal += item.size
       }).on('end', startDownload)
 
-      function startDownload() {
+      function startDownload () {
         pump(archive.createEntryStream(), download, function (err) {
           cb(err, swarm)
         })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "discovery-swarm": "^2.0.3",
     "folder-walker": "^1.3.0",
     "home-dir": "^1.0.0",
-    "hyperdrive": "^3.2.1",
+    "hyperdrive": "^3.3.0",
     "level-party": "^3.0.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/tests/link.js
+++ b/tests/link.js
@@ -67,7 +67,7 @@ test('connects if link process starts second', function (t) {
 
     cloner.stdout.match(function (output) {
       var str = output.toString()
-      if (relinker && str.indexOf('Download complete') > -1) {
+      if (relinker && str.indexOf('Download Complete') > -1) {
         cloner.kill()
         relinker.kill()
         relinker.end()

--- a/tests/link.js
+++ b/tests/link.js
@@ -67,7 +67,7 @@ test('connects if link process starts second', function (t) {
 
     cloner.stdout.match(function (output) {
       var str = output.toString()
-      if (relinker && str.indexOf('Download Complete') > -1) {
+      if (relinker && str.indexOf('Downloaded') > -1) {
         cloner.kill()
         relinker.kill()
         relinker.end()

--- a/tests/link_stats.js
+++ b/tests/link_stats.js
@@ -38,7 +38,7 @@ test('prints out all of the files', function (t) {
     if (!downloadFinished) return false
 
     var fileList = output.split('\n').filter(function (line) {
-      return line.indexOf('[Done]') > -1
+      return line.indexOf('[Done]') > -1 && line.indexOf('Files Read') === -1
     })
     t.ok(fileList.length === 2, 'two files printed done')
 

--- a/tests/link_stats.js
+++ b/tests/link_stats.js
@@ -34,7 +34,7 @@ test('prints correct file & directory stats', function (t) {
 test('prints out all of the files', function (t) {
   var st = spawn(t, dat + ' link ' + datSample + ' --home=' + tmp)
   st.stdout.match(function (output) {
-    var downloadFinished = output.indexOf('Your Dat Link') > -1
+    var downloadFinished = output.indexOf('dat://') > -1
     if (!downloadFinished) return false
 
     var fileList = output.split('\n').filter(function (line) {


### PR DESCRIPTION
* Adds files progress to download stats
* Keeps `Your Dat Link` always on bottom
* After Link/Download complete, keep stats on output and mark `[Done]`
* *Tries* to make sharing/download & connection status clearer

It was feeling a bit cluttered at the bottom, so I separated out the `[Status]` bit. Still not sure if I like how I did it, happy to see other options.


The stats object for both Add & Download looks like this: 

```javascript
  var stats = {
    progress: { // progress of adding/downloading
      bytesRead: 0,
      filesRead: 0,
      directories: 0
    },
    total: { // Total size of the archive, doesn't change for a hash
      bytesTotal: 0,
      filesTotal: 0
    },
    fileQueue: [] // Complete files are removed from queue after printing
  }
```

## Download In Progress View
<img width="706" alt="screen shot 2016-02-24 at 09 49 58" src="https://cloud.githubusercontent.com/assets/684965/13295084/04fe086a-dadc-11e5-9263-c2636d18f6cd.png">

## Download Finished View
<img width="728" alt="screen shot 2016-02-24 at 09 26 12" src="https://cloud.githubusercontent.com/assets/684965/13295017/996c9a3a-dadb-11e5-914b-8f1ee6ad9dfe.png">

## Linking Finished View
<img width="698" alt="screen shot 2016-02-24 at 09 25 03" src="https://cloud.githubusercontent.com/assets/684965/13295028/a5184302-dadb-11e5-8839-52abb310d6bf.png">