### PR TITLE
Add upload stats to CLI output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -28,6 +28,7 @@ var swarm = require('discovery-swarm')
 var chalk = require('chalk')
 var crypto = require('crypto')
 var pump = require('pump')
+var xtend = require('xtend')
 var dat = require('./index.js')
 var usage = require('./usage')
 
@@ -136,11 +137,11 @@ function link (loc, db) {
       if (err) throw err
       db.joinTcpSwarm({link: link, port: args.port}, function (_err, swarm) {
         // ignore _err
-        startProgressLogging({swarm: swarm})
+        stats.swarm = swarm
+        startProgressLogging(stats)
       })
     })
-    stats.progress = statsProgress.progress
-    stats.fileQueue = statsProgress.fileQueue
+    stats = xtend(stats, statsProgress)
 
     var addInterval = setInterval(function () {
       printAddProgress(stats)
@@ -238,6 +239,12 @@ function printSwarmStatus (stats) {
   else if (swarm.downloading) msg += chalk.bold('[Downloading] ')
   msg += chalk.underline.blue('dat://' + swarm.link)
 
+  if (!swarm.downloading && stats.uploaded.bytesRead > 0) {
+    msg += '\n'
+    msg += chalk.bold('[Upload] ') + prettyBytes(stats.uploaded.bytesRead)
+    msg += ' at ' + prettyBytes(stats.uploadRate()) + '/s'
+  }
+  msg += '\n'
   logger.stdout(msg)
 
   function downloadMsg () {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dns-discovery": "^5.3.3",
     "folder-walker": "^1.3.0",
     "home-dir": "^1.0.0",
-    "hyperdrive": "^3.4.1",
+    "hyperdrive": "^3.5.0",
     "level-party": "^3.0.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Shows upload stats (total bytes, speed) when data is being uploaded. Works for `dat link` and after a dat is downloaded and sharing starts.

Also:
* Upgrade Hyperdrive version
* Use xtend for nice stats object