### PR TITLE
Improve stat output for edge cases

### DIFF
--- a/commands/download.js
+++ b/commands/download.js
@@ -32,6 +32,9 @@ module.exports = function (args) {
     updateStats()
   })
 
+  dat.on('archive-updated', updateStats)
+  dat.on('file-downloaded', updateStats)
+
   dat.on('download-finished', function () {
     downloadTxt = 'Downloaded '
     updateStats()
@@ -55,9 +58,10 @@ module.exports = function (args) {
 
   function updateStats () {
     var stats = dat.stats
-    var msg = ui.progress(stats.bytesDown / stats.bytesTotal)
-    msg += ' ' + downloadTxt + chalk.bold(stats.filesTotal) + ' files'
-    msg += chalk.dim(' (' + prettyBytes(stats.bytesDown) + '/' + prettyBytes(stats.bytesTotal) + ')')
+    if (stats.bytesProgress >= stats.bytesTotal) downloadTxt = 'Downloaded '
+    var msg = ui.progress(stats.bytesProgress / stats.bytesTotal)
+    msg += ' ' + downloadTxt + chalk.bold(stats.filesTotal) + ' items'
+    msg += chalk.dim(' (' + prettyBytes(stats.bytesProgress) + '/' + prettyBytes(stats.bytesTotal) + ')')
     log.status(msg + '\n', 0)
   }
 }

--- a/commands/share.js
+++ b/commands/share.js
@@ -27,8 +27,8 @@ module.exports = function (args) {
 
   dat.on('file-counted', function () {
     var msg = 'Calculating Size: '
-    msg += dat.appendStats.files + ' files '
-    msg += chalk.dim('(' + prettyBytes(dat.appendStats.bytes) + ')')
+    msg += dat.stats.filesTotal + ' items '
+    msg += chalk.dim('(' + prettyBytes(dat.stats.bytesTotal) + ')')
     log.status(msg + '\n', 0)
   })
 
@@ -49,7 +49,7 @@ module.exports = function (args) {
   })
 
   dat.on('archive-updated', function () {
-    addText = 'Updated '
+    addText = 'Updating '
     updated = true
     updateStats()
   })
@@ -59,7 +59,6 @@ module.exports = function (args) {
   setInterval(function () {
     printSwarm()
     log.print()
-    // console.log('here', log)
   }, args.logspeed)
   log.print()
 
@@ -67,19 +66,20 @@ module.exports = function (args) {
     log.status(ui.swarmMsg(dat), 1)
   }
 
-  function updateStats (data) {
+  function updateStats () {
     var stats = dat.stats
     var files = stats.filesTotal
-    var bytesTotal = dat.appendStats.bytes
-    var bytesProgress = stats.bytesTotal
+    var bytesTotal = stats.bytesTotal
+    var bytesProgress = stats.bytesProgress
+
     if (updated) {
+      if (stats.filesTotal === stats.filesProgress) addText = 'Updated '
       files = files - initFileCount
-      bytesProgress = stats.bytesTotal // TODO: update progress for live
       bytesTotal = stats.bytesTotal
     }
 
     var msg = ui.progress(bytesProgress / bytesTotal)
-    msg += ' ' + addText + chalk.bold(files) + ' files'
+    msg += ' ' + addText + chalk.bold(files) + ' items'
     msg += chalk.dim(' (' + prettyBytes(bytesProgress) + '/' + prettyBytes(bytesTotal) + ')')
     log.status(msg + '\n', 0)
   }

--- a/docs/meta/changelog.md
+++ b/docs/meta/changelog.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Use yolowatch module for recursive live updates
 * Improved stats for edge cases
 * Print link with --quiet argument
+* Better stat & progress output with hyperdrive/hypercore events
 
 ### Changed
 * Simplified and clean up CLI output

--- a/docs/meta/changelog.md
+++ b/docs/meta/changelog.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Improve modularity of library
 * Move logger module into own npm package, status-logger
 * Store key in .dat db without encoding as hex string (#498)
+* upgrade to hyperdrive 7
 
 ### Removed
 * List download option (will be re-added pending a hyperdrive update)

--- a/lib/append.js
+++ b/lib/append.js
@@ -2,11 +2,6 @@ var walker = require('folder-walker')
 var each = require('stream-each')
 
 module.exports.initialAppend = function (dat, cb) {
-  dat.appendStats = {
-    files: 0,
-    dirs: 0,
-    bytes: 0
-  }
   each(walker(dat.dir, {filter: dat.ignore}), countFiles, function (err) {
     if (err) cb(err)
     dat.emit('append-ready')
@@ -23,12 +18,8 @@ module.exports.initialAppend = function (dat, cb) {
 
   function countFiles (data, next) {
     dat.emit('file-counted')
-    if (data.type === 'directory') {
-      dat.appendStats.dirs += 1
-    } else {
-      dat.appendStats.files += 1
-      dat.appendStats.bytes += data.stat.size
-    }
+    dat.stats.filesTotal += 1
+    dat.stats.bytesTotal += data.stat.size
     next()
   }
 
@@ -56,14 +47,16 @@ module.exports.initialAppend = function (dat, cb) {
 
 module.exports.liveAppend = function (dat, data) {
   if (!dat.ignore(data.filepath)) return
+  dat.stats.bytesTotal += data.stat.size
+  dat.stats.filesTotal += 1
   dat.archive.append({type: data.type, name: data.relname}, function () {
     updateStats(dat, data)
   })
 }
 
 function updateStats (dat, data, existing) {
-  if (data.type === 'file') dat.stats.filesTotal += 1
-  dat.stats.bytesTotal = dat.archive.content ? dat.archive.content.bytes : 0
+  dat.stats.filesProgress += 1
+  dat.stats.bytesProgress += data.stat.size
   if (existing) dat.emit('file-exists', data)
   else dat.emit('file-added', data)
 }

--- a/lib/dat.js
+++ b/lib/dat.js
@@ -29,7 +29,9 @@ function Dat (opts) {
   this.swarm = null
   this.stats = {
     filesTotal: 0,
+    filesProgress: 0,
     bytesTotal: 0,
+    bytesProgress: 0,
     bytesUp: 0,
     bytesDown: 0,
     rateUp: speedometer(),
@@ -89,7 +91,7 @@ Dat.prototype.share = function (cb) {
 
     if (archive.key && !archive.owner) {
       // TODO: allow this but change to download
-      cb('Dat previously downloaded. Run dat ' + encoding.encode(archive.key) + ' to resume')
+      cb(new Error('Dat previously downloaded. Run dat ' + encoding.encode(archive.key) + ' to resume'))
     }
 
     if ((archive.live || archive.owner) && archive.key) {
@@ -130,12 +132,12 @@ Dat.prototype.share = function (cb) {
         var watch = yoloWatch(self.dir, {filter: self.ignore})
         watch.on('changed', function (name, data) {
           if (name === self.dir) return
-          append.liveAppend(self, data)
           self.emit('archive-updated')
+          append.liveAppend(self, data)
         })
         watch.on('added', function (name, data) {
-          append.liveAppend(self, data)
           self.emit('archive-updated')
+          append.liveAppend(self, data)
         })
       }
     })
@@ -146,7 +148,6 @@ Dat.prototype.download = function (cb) {
   var self = this
   var archive = self.archive
 
-  self.stats.filesDown = 0
   self.joinSwarm()
   self.emit('key', archive.key.toString('hex'))
 
@@ -156,22 +157,37 @@ Dat.prototype.download = function (cb) {
     updateTotalStats()
 
     each(archive.list({live: archive.live}), function (data, next) {
-      var startBytes = self.stats.bytesDown
+      var startBytes = self.stats.bytesProgress
       archive.download(data, function (err) {
         if (err) return cb(err)
-        self.stats.filesDown += 1
+        self.stats.filesProgress += 1
         self.emit('file-downloaded', data)
-        if (startBytes === self.stats.bytesDown) self.stats.bytesDown += data.length // file already exists
-        if (self.stats.filesDown === self.stats.filesTotal) done()
+        if (startBytes === self.stats.bytesProgress) self.stats.bytesProgress += data.length // file already exists
+        if (self.stats.filesProgress === self.stats.filesTotal) self.emit('download-finished')
         else next()
       })
-    }, done)
+    }, function (err) {
+      if (err) return cb(err)
+      cb(null)
+    })
+
+    archive.content.on('download-finished', function () {
+      self.emit('download-finished')
+    })
+  })
+
+  archive.metadata.once('download-finished', function () {
+    updateTotalStats()
+  })
+
+  archive.metadata.on('update', function () {
+    // TODO: better stats for live updates
+    updateTotalStats()
+    self.emit('archive-updated')
   })
 
   archive.on('download', function (data) {
-    // TODO: better way to update totals on live updates?
-    updateTotalStats()
-
+    self.stats.bytesProgress += data.length
     self.stats.bytesDown += data.length
     self.stats.rateDown(data.length)
     self.emit('download', data)
@@ -186,11 +202,6 @@ Dat.prototype.download = function (cb) {
   function updateTotalStats () {
     self.stats.filesTotal = archive.metadata.blocks - 1 // first block is header.
     self.stats.bytesTotal = archive.content ? archive.content.bytes : 0
-  }
-
-  function done () {
-    self.emit('download-finished')
-    if (!archive.live) cb(null)
   }
 }
 

--- a/lib/dat.js
+++ b/lib/dat.js
@@ -156,32 +156,32 @@ Dat.prototype.download = function (cb) {
     self.db.put('!dat!key', archive.key.toString('hex'))
     updateTotalStats()
 
+    archive.content.on('download-finished', function () {
+      self.emit('download-finished')
+    })
+
     each(archive.list({live: archive.live}), function (data, next) {
       var startBytes = self.stats.bytesProgress
       archive.download(data, function (err) {
         if (err) return cb(err)
         self.stats.filesProgress += 1
         self.emit('file-downloaded', data)
-        if (startBytes === self.stats.bytesProgress) self.stats.bytesProgress += data.length // file already exists
-        if (self.stats.filesProgress === self.stats.filesTotal) self.emit('download-finished')
-        else next()
+        if (startBytes === self.stats.bytesProgress) {
+          // TODO: better way to measure progress with existing files
+          self.stats.bytesProgress += data.length // file already exists
+        }
+        // if (self.stats.filesProgress === self.stats.filesTotal) self.emit('download-finished')
+        next()
       })
     }, function (err) {
       if (err) return cb(err)
       cb(null)
     })
-
-    archive.content.on('download-finished', function () {
-      self.emit('download-finished')
-    })
   })
 
-  archive.metadata.once('download-finished', function () {
-    updateTotalStats()
-  })
+  archive.metadata.once('download-finished', updateTotalStats)
 
   archive.metadata.on('update', function () {
-    // TODO: better stats for live updates
     updateTotalStats()
     self.emit('archive-updated')
   })

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -7,9 +7,10 @@ module.exports.progress = function (percent) {
   var ends = ['[', ']']
   var spacer = Array(width).join(' ')
   var progressVal = ''
+  if (percent > 1) percent = 1 // TODO: remove when we fix stats
   var val = Math.round(percent * width)
 
-  if (val && val > 0) {
+  if (isFinite(val) && val > 0) {
     progressVal = Array(val).join('=')
     progressVal += cap
   }
@@ -24,8 +25,8 @@ module.exports.swarmMsg = function (dat) {
   var msg = ''
   if (dat.swarm && dat.swarm.connections) msg = 'Connected to ' + dat.swarm.connections + ' peers. '
   else msg = 'Waiting for connections. '
-  if (dat.stats.bytesDown) msg += 'Downloading ' + prettyBytes(dat.stats.rateDown()) + '/s. '
-  if (dat.stats.bytesUp) msg += 'Uploading ' + prettyBytes(dat.stats.rateUp()) + '/s. '
+  if (dat.stats.rateDown()) msg += 'Downloading ' + prettyBytes(dat.stats.rateDown()) + '/s. '
+  if (dat.stats.rateUp()) msg += 'Uploading ' + prettyBytes(dat.stats.rateUp()) + '/s. '
   if (dat.archive.live && dat.archive.owner) msg += 'Watching for updates...'
   return msg
 }

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -27,7 +27,7 @@ module.exports.swarmMsg = function (dat) {
   else msg = 'Waiting for connections. '
   if (dat.stats.rateDown()) msg += 'Downloading ' + prettyBytes(dat.stats.rateDown()) + '/s. '
   if (dat.stats.rateUp()) msg += 'Uploading ' + prettyBytes(dat.stats.rateUp()) + '/s. '
-  if (dat.archive.live && dat.archive.owner) msg += 'Watching for updates...'
+  if (dat.archive && dat.archive && dat.archive.live && dat.archive.owner) msg += 'Watching for updates...'
   return msg
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "discovery-swarm": "^4.0.0",
     "dns-discovery": "^5.3.3",
     "folder-walker": "^3.0.0",
-    "hyperdrive": "^6.6.1",
+    "hyperdrive": "^7.0.0",
     "hyperdrive-archive-swarm": "^3.1.0",
     "level": "^1.4.0",
     "minimist": "^1.2.0",

--- a/tests/download.js
+++ b/tests/download.js
@@ -114,7 +114,7 @@ test('download transfers files', function (t) {
       var contains = output.indexOf('Downloaded') > -1
       if (!contains || !share) return false
 
-      var hasFiles = output.indexOf('3 files') > -1
+      var hasFiles = output.indexOf('3 items') > -1
       t.ok(hasFiles, 'file number is 3')
 
       var hasSize = output.indexOf('1.44 kB') > -1

--- a/tests/share.js
+++ b/tests/share.js
@@ -104,7 +104,7 @@ test('prints file information (live)', function (t) {
     if (!finished) return false
 
     t.ok(output.match(/3 items/), 'File count correct')
-    t.ok(output.match(/1\.54 kB/), 'File size correct')
+    t.ok(output.match(/1\.\d{1,2} kB/), 'File size correct')
 
     st.kill()
     cleanDat()
@@ -121,7 +121,7 @@ test('prints file information (snapshot)', function (t) {
     if (!finished) return false
 
     t.ok(output.match(/3 items/), 'File count correct')
-    t.ok(output.match(/1\.54 kB/), 'File size correct')
+    t.ok(output.match(/1\.\d{1,2} kB/), 'File size correct')
 
     st.kill()
     cleanDat()

--- a/tests/share.js
+++ b/tests/share.js
@@ -103,8 +103,8 @@ test('prints file information (live)', function (t) {
     var finished = output.match('Added')
     if (!finished) return false
 
-    t.ok(output.match(/2 files/), 'File count correct')
-    t.ok(output.match(/1\.44 kB/), 'File size correct')
+    t.ok(output.match(/3 items/), 'File count correct')
+    t.ok(output.match(/1\.54 kB/), 'File size correct')
 
     st.kill()
     cleanDat()
@@ -120,8 +120,8 @@ test('prints file information (snapshot)', function (t) {
     var finished = output.match('Added')
     if (!finished) return false
 
-    t.ok(output.match(/2 files/), 'File count correct')
-    t.ok(output.match(/1\.44 kB/), 'File size correct')
+    t.ok(output.match(/3 items/), 'File count correct')
+    t.ok(output.match(/1\.54 kB/), 'File size correct')
 
     st.kill()
     cleanDat()


### PR DESCRIPTION
* Use hypercore feed events to improve edge case stats.
* Remove `dat.appendStats` and use `stats.filesProgress` and `stats.bytesProgress` to be consistent across share and download.
* Print out **item** count instead of **file** count (to be consistent, only items are available in download right now)